### PR TITLE
Adding simulation interfaces

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,8 @@
+rem ********************
+rem *   Requirements   * 
+rem ********************
+rem * Java JDK 12 
+rem * Gradle 3.2 >= version < 7.x
+SET GRADLE_HOME=
+SET JAVA_HOME=
+%GRADLE_HOME%/bin/gradle clean build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.scaleoutsoftware.digitaltwin'
-version '2.1.3'
+version '2.2.1'
 
 sourceCompatibility = 1.8
 
@@ -41,7 +41,7 @@ task createPom  {
         project {
             groupId 'com.scaleoutsoftware.digitaltwin'
             artifactId 'core'
-            version '2.1.3'
+            version '2.2.1'
 
             inceptionYear '2020'
         }

--- a/src/main/java/com/scaleoutsoftware/digitaltwin/core/DigitalTwinBase.java
+++ b/src/main/java/com/scaleoutsoftware/digitaltwin/core/DigitalTwinBase.java
@@ -24,9 +24,30 @@ import java.util.HashMap;
 public abstract class DigitalTwinBase {
 
     /* capitalized to match .NET serialization */
+    /**
+     * The identifier for this twin instance
+     */
     public String Id = "";
+
+    /**
+     * The model this twin instance belongs to.
+     */
     public String Model = "";
+
+    /**
+     * The timer handlers for this twin instance.
+     */
     public HashMap<String,TimerMetadata> TimerHandlers = new HashMap<>();
+
+    public long NextSimulationTime = 0L;
+
+    public long getNextSimulationTimeMs() {
+        return NextSimulationTime;
+    }
+
+    public void setNextSimulationTime(long nextSimulationTime) {
+        NextSimulationTime = nextSimulationTime;
+    }
 
     /**
      * The identifier of this DigitalTwin.

--- a/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelProcessor.java
+++ b/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelProcessor.java
@@ -1,0 +1,20 @@
+package com.scaleoutsoftware.digitaltwin.core;
+
+import java.io.Serializable;
+
+/**
+ * Processes simulation events for a real-time digital twin.
+ * @param <T> the type of the digital twin.
+ */
+public abstract class ModelProcessor<T extends DigitalTwinBase> implements Serializable {
+
+    /**
+     * Processes simulation events for a real-time digital twin.
+     * @param context the processing context.
+     * @param instance the digital twin instance.
+     * @param epoch the current time interval of the simulation.
+     * @return {@link ProcessingResult#UpdateDigitalTwin} to update the digital twin, or
+     * {@link ProcessingResult#NoUpdate} to ignore the changes.
+     */
+    public abstract ProcessingResult processModel(ProcessingContext context, T instance, long epoch);
+}

--- a/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelSchema.java
+++ b/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelSchema.java
@@ -24,13 +24,14 @@ import java.util.List;
 public class ModelSchema {
     private final String                            modelType;
     private final String                            messageProcessorType;
+    private final String                            modelProcessorType;
     private final String                            messageType;
     private final String                            assemblyName;
     private final String                            azureDigitalTwinModelName;
     private final List<AlertProviderConfiguration>  alertProviders;
 
     private ModelSchema() {
-        modelType = messageProcessorType = messageType = assemblyName = azureDigitalTwinModelName = null;
+        modelType = messageProcessorType = modelProcessorType = messageType = assemblyName = azureDigitalTwinModelName = null;
         alertProviders = null;
     }
 
@@ -56,6 +57,7 @@ public class ModelSchema {
         }
         modelType                   = dtClass;
         messageProcessorType        = mpClass;
+        modelProcessorType          = null;
         messageType                 = msgClass;
         assemblyName                = "NOT_USED_BY_JAVA_MODELS";
         alertProviders              = null;
@@ -87,6 +89,7 @@ public class ModelSchema {
         }
         modelType                   = dtClass;
         messageProcessorType        = mpClass;
+        modelProcessorType          = null;
         messageType                 = msgClass;
         assemblyName                = "NOT_USED_BY_JAVA_MODELS";
         azureDigitalTwinModelName   = null;
@@ -119,6 +122,42 @@ public class ModelSchema {
         }
         modelType                   = dtClass;
         messageProcessorType        = mpClass;
+        modelProcessorType          = null;
+        messageType                 = msgClass;
+        assemblyName                = "NOT_USED_BY_JAVA_MODELS";
+        azureDigitalTwinModelName   = adtModelName;
+        alertProviders              = alertingProviders;
+    }
+
+    /**
+     *
+     * @param dtClass the digital twin class implementation.
+     * @param mpClass the message processor class implementation.
+     * @param msgClass a JSON serializable message class.
+     * @param modelProcessorClass the model processor class implementation.
+     * @param adtModelName the Azure Digital Twin model name.
+     * @param alertingProviders the alerting provider configurations.
+     */
+    public ModelSchema(
+            String dtClass,
+            String mpClass,
+            String msgClass,
+            String modelProcessorClass,
+            String adtModelName,
+            List<AlertProviderConfiguration> alertingProviders) {
+        if( (dtClass    == null || dtClass.isEmpty()) ||
+                (mpClass    == null || mpClass.isEmpty()) ||
+                (msgClass   == null || msgClass.isEmpty())
+        ) {
+            throw new IllegalArgumentException(String.format("Expected value for dtClass, mpClass, and msgClass; actual values: %s, %s, %s",
+                    (dtClass == null ? "null dtClass" : dtClass),
+                    (mpClass == null ? "null mpClass" : mpClass),
+                    (msgClass == null ? "null mpClass" : msgClass)
+            ));
+        }
+        modelType                   = dtClass;
+        messageProcessorType        = mpClass;
+        modelProcessorType          = modelProcessorClass;
         messageType                 = msgClass;
         assemblyName                = "NOT_USED_BY_JAVA_MODELS";
         azureDigitalTwinModelName   = adtModelName;
@@ -147,6 +186,14 @@ public class ModelSchema {
      */
     public String getMessageProcessorType() {
         return messageProcessorType;
+    }
+
+    /**
+     * Retrieve the model processor type (a {@link ModelProcessor} implementation).
+     * @return the model processor type.
+     */
+    public String getModelProcessorType() {
+        return modelProcessorType;
     }
 
     /**

--- a/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelSimulation.java
+++ b/src/main/java/com/scaleoutsoftware/digitaltwin/core/ModelSimulation.java
@@ -1,0 +1,57 @@
+package com.scaleoutsoftware.digitaltwin.core;
+
+import java.time.Duration;
+
+/**
+ * The ModelSimulation interface is used to interact with the current DigitalTwin simulation.
+ */
+public interface ModelSimulation {
+    /**
+     * Retrieves the current simulation time increment.
+     * @return the simulation time increment.
+     */
+    Duration getSimulationTimeIncrement();
+
+    /**
+     * Delay simulation processing for this DigitalTwin instance for a duration of time.
+     *
+     * Simulation processing will be delayed for the duration specified relative to the current simulation time.
+     * @param duration the duration to delay.
+     * @return {@link SendingResult#Handled} if the delay was process or {@link SendingResult#NotHandled}
+     * if the delay was not processed.
+     */
+    SendingResult delay(Duration duration);
+
+    /**
+     * Send a list of JSON serialized messages to a DigitalTwin instance that will be processed by the DigitalTwin
+     * models {@link MessageProcessor#processMessages(ProcessingContext, DigitalTwinBase, Iterable)} method.
+     * @param telemetryMessage the list of JSON serialized messages
+     * @return {@link SendingResult#Handled} if the messages were processed, {@link SendingResult#Enqueued} if
+     * the messages are in process of being handled, or {@link SendingResult#NotHandled} if the delay was not processed.
+     */
+    SendingResult emitTelemetry(byte[] telemetryMessage);
+
+    /**
+     * Create a new instance for simulation processing.
+     * @param modelName the model name.
+     * @param instanceId the instance id.
+     * @return {@link SendingResult#Handled} if the instance was created, {@link SendingResult#Enqueued} if the instance
+     * is in process of being created, or {@link SendingResult#NotHandled} if the instance could not be created.
+     */
+    SendingResult createInstance(String modelName, String instanceId);
+
+    /**
+     * Delete a digital twin instance from simulation processing.
+     * @param modelName the model name.
+     * @param instanceId the instance id.
+     * @return {@link SendingResult#Handled} if the instance was deleted, {@link SendingResult#Enqueued} if the instance
+     * is in process of being deleted, or {@link SendingResult#NotHandled} if the instance could not be deleted.
+     */
+    SendingResult deleteInstance(String modelName, String instanceId);
+
+    /**
+     * Deletes this digital twin instance.
+     * @return this local request will always return {@link SendingResult#Handled}.
+     */
+    SendingResult deleteThisInstance();
+}

--- a/src/main/java/com/scaleoutsoftware/digitaltwin/core/ProcessingContext.java
+++ b/src/main/java/com/scaleoutsoftware/digitaltwin/core/ProcessingContext.java
@@ -154,5 +154,11 @@ public abstract class ProcessingContext implements Serializable {
      */
     public abstract TimerActionResult stopTimer(String timerName);
 
+    /**
+     * Retrieve the ModelSimulation.
+     * @return the ModelSimulation.
+     */
+    public abstract ModelSimulation getModelSimulation();
+
 
 }


### PR DESCRIPTION
Now support simulation. ModelSimulations can send messages to other twins and emit telemetry to the current model.